### PR TITLE
Inject dependencies using protocols instead of structs

### DIFF
--- a/MyTube/Core/Data/CoreDataVideoPersistenceRepository.swift
+++ b/MyTube/Core/Data/CoreDataVideoPersistenceRepository.swift
@@ -8,66 +8,62 @@
 import Foundation
 import CoreData
 
-struct CoreDataVideoPersistenceRepository {
-    var saveVideo: (Video) throws -> Void
-    var deleteVideo: (Video) throws -> Void
-    var savedVideos: () throws -> [Video]
+protocol CoreDataVideoPersistenceRepositoryType {
+    func saveVideo(_ video: Video) throws
+    func deleteVideo(_ video: Video) throws
+    func savedVideos() throws -> [Video]
+}
 
-    init(
-        saveVideo: @escaping (Video) throws -> Void,
-        deleteVideo: @escaping (Video) throws -> Void,
-        savedVideos: @escaping () throws -> [Video]
-    ) {
-        self.saveVideo = saveVideo
-        self.deleteVideo = deleteVideo
-        self.savedVideos = savedVideos
+struct CoreDataVideoPersistenceRepository {
+    private let  managedObjectContext: NSManagedObjectContext
+
+    init(managedObjectContext: NSManagedObjectContext) {
+        self.managedObjectContext = managedObjectContext
     }
 }
 
-extension CoreDataVideoPersistenceRepository {
-    static func live(managedObjectContext: NSManagedObjectContext) -> Self {
-        .init(
-            saveVideo: { video in
-                let savedVideo = CDVideo(context: managedObjectContext)
-                savedVideo.id = video.id
-                savedVideo.title = video.title
-                savedVideo.thumbnailUrl = video.imageThumbnailUrl?.absoluteString
-                savedVideo.dateSaved = .init()
+extension CoreDataVideoPersistenceRepository: CoreDataVideoPersistenceRepositoryType {
+    func saveVideo(_ video: Video) throws {
+        let savedVideo = CDVideo(context: managedObjectContext)
+        savedVideo.id = video.id
+        savedVideo.title = video.title
+        savedVideo.thumbnailUrl = video.imageThumbnailUrl?.absoluteString
+        savedVideo.dateSaved = .init()
 
-                try managedObjectContext.save()
-            },
-            deleteVideo: { video in
-                let fetchRequest: NSFetchRequest<CDVideo> = CDVideo.fetchRequest()
-                fetchRequest.sortDescriptors = [
-                    NSSortDescriptor(key: "id", ascending: true)
-                ]
-                fetchRequest.predicate = .init(format: "id == \(video.id)")
+        try managedObjectContext.save()
+    }
 
-                let videos = try managedObjectContext.fetch(fetchRequest)
-                videos.forEach {
-                    managedObjectContext.delete($0)
-                }
+    func deleteVideo(_ video: Video) throws {
+        let fetchRequest: NSFetchRequest<CDVideo> = CDVideo.fetchRequest()
+        fetchRequest.sortDescriptors = [
+            NSSortDescriptor(key: "id", ascending: true)
+        ]
+        fetchRequest.predicate = .init(format: "id == \(video.id)")
 
-                try managedObjectContext.save()
-            },
-            savedVideos: {
-                let fetchRequest: NSFetchRequest<CDVideo> = CDVideo.fetchRequest()
-                fetchRequest.sortDescriptors = [NSSortDescriptor(key: "dateSaved", ascending: true)]
-                
-                let videos = try managedObjectContext.fetch(fetchRequest)
+        let videos = try managedObjectContext.fetch(fetchRequest)
+        videos.forEach {
+            managedObjectContext.delete($0)
+        }
 
-                return videos.compactMap {
-                    guard let id = $0.id, let title = $0.title else {
-                        return nil
-                    }
+        try managedObjectContext.save()
+    }
 
-                    return .init(
-                        id: id,
-                        title: title,
-                        imageThumbnailUrl: $0.thumbnailUrl.map { URL(string: $0) } ?? nil
-                    )
-                }
+    func savedVideos() throws -> [Video] {
+        let fetchRequest: NSFetchRequest<CDVideo> = CDVideo.fetchRequest()
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "dateSaved", ascending: true)]
+
+        let videos = try managedObjectContext.fetch(fetchRequest)
+
+        return videos.compactMap {
+            guard let id = $0.id, let title = $0.title else {
+                return nil
             }
-        )
+
+            return .init(
+                id: id,
+                title: title,
+                imageThumbnailUrl: $0.thumbnailUrl.map { URL(string: $0) } ?? nil
+            )
+        }
     }
 }

--- a/MyTube/Core/Data/LikeVideoRepository+CoreData.swift
+++ b/MyTube/Core/Data/LikeVideoRepository+CoreData.swift
@@ -8,35 +8,40 @@
 import Foundation
 import Combine
 
-extension LikeVideoRepository {
-    static func coreData(repository: CoreDataVideoPersistenceRepository) -> Self {
-        .init(
-            like: { video in
-                Deferred {
-                    Future { promise in
-                        do {
-                            try repository.saveVideo(video)
-                            promise(.success(true))
-                        } catch {
-                            promise(.failure(error))
-                        }
-                    }
+struct CoreDataLikeVideoRepository {
+    private var repository: CoreDataVideoPersistenceRepositoryType
+
+    init(repository: CoreDataVideoPersistenceRepositoryType) {
+        self.repository = repository
+    }
+}
+
+extension CoreDataLikeVideoRepository: LikeVideoRepositoryType {
+    func like(_ video: Video) -> AnyPublisher<Bool, Error> {
+        Deferred {
+            Future { promise in
+                do {
+                    try repository.saveVideo(video)
+                    promise(.success(true))
+                } catch {
+                    promise(.failure(error))
                 }
-                .eraseToAnyPublisher()
-            },
-            dislike: { video in
-                Deferred {
-                    Future { promise in
-                        do {
-                            try repository.deleteVideo(video)
-                            promise(.success(true))
-                        } catch {
-                            promise(.failure(error))
-                        }
-                    }
-                }
-                .eraseToAnyPublisher()
             }
-        )
+        }
+        .eraseToAnyPublisher()
+    }
+
+    func dislike(_ video: Video) -> AnyPublisher<Bool, Error> {
+        Deferred {
+            Future { promise in
+                do {
+                    try repository.deleteVideo(video)
+                    promise(.success(true))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
     }
 }

--- a/MyTube/Core/Domain/LikeVideoUseCase.swift
+++ b/MyTube/Core/Domain/LikeVideoUseCase.swift
@@ -8,18 +8,30 @@
 import Foundation
 import Combine
 
+protocol LikeVideoUseCaseType {
+    func like(_ video: Video) -> AnyPublisher<Bool, Error>
+    func dislike(_ video: Video) -> AnyPublisher<Bool, Error>
+}
+
+protocol LikeVideoRepositoryType {
+    func like(_ video: Video) -> AnyPublisher<Bool, Error>
+    func dislike(_ video: Video) -> AnyPublisher<Bool, Error>
+}
+
 struct LikeVideoUseCase {
-    var like: (Video) -> AnyPublisher<Bool, Error>
-    var dislike: (Video) -> AnyPublisher<Bool, Error>
+    private var likeVideoRepository: LikeVideoRepositoryType
+
+    init(repository: LikeVideoRepositoryType) {
+        self.likeVideoRepository = repository
+    }
 }
 
-struct LikeVideoRepository {
-    var like: (Video) -> AnyPublisher<Bool, Error>
-    var dislike: (Video) -> AnyPublisher<Bool, Error>
-}
+extension LikeVideoUseCase: LikeVideoUseCaseType {
+    func like(_ video: Video) -> AnyPublisher<Bool, Error> {
+        likeVideoRepository.like(video)
+    }
 
-extension LikeVideoUseCase {
-    static func live(repository: LikeVideoRepository) -> Self {
-        .init(like: repository.like, dislike: repository.dislike)
+    func dislike(_ video: Video) -> AnyPublisher<Bool, Error> {
+        likeVideoRepository.dislike(video)
     }
 }

--- a/MyTube/Core/Domain/SearchVideosUseCase.swift
+++ b/MyTube/Core/Domain/SearchVideosUseCase.swift
@@ -8,23 +8,21 @@
 import Foundation
 import Combine
 
-struct SearchVideosUseCase {
-    var videosMatching: (String) -> AnyPublisher<[Video], Error>
+protocol SearchVideosUseCaseType {
+    func videos(matching searchString: String) -> AnyPublisher<[Video], Error>
 }
 
-extension SearchVideosUseCase {
-    static var live: Self {
-        .init(
-            videosMatching: {
-                YoutubeVideosRepository().videos(for: $0)
-                    .map {
-                        $0.map {
-                            .init(id: $0.id, title: $0.title, imageThumbnailUrl: $0.imageThumbnailUrl)
-                        }
-                    }
-                    .mapError { $0 as Error }
-                    .eraseToAnyPublisher()
+struct SearchVideosUseCase {}
+
+extension SearchVideosUseCase: SearchVideosUseCaseType {
+    func videos(matching searchString: String) -> AnyPublisher<[Video], Error> {
+        YoutubeVideosRepository().videos(for: searchString)
+            .map {
+                $0.map {
+                    .init(id: $0.id, title: $0.title, imageThumbnailUrl: $0.imageThumbnailUrl)
+                }
             }
-        )
+            .mapError { $0 as Error }
+            .eraseToAnyPublisher()
     }
 }

--- a/MyTube/Features/Video Detail/VideoDetailView.swift
+++ b/MyTube/Features/Video Detail/VideoDetailView.swift
@@ -89,22 +89,25 @@ struct VideoDetailView_Previews: PreviewProvider {
                         ),
                         reducer: .empty,
                         environment: VideoDetailViewModel.Environment(
-                            likeVideo: .init(
-                                like: { _ in
-                                    Just(true)
-                                        .setFailureType(to: Error.self)
-                                        .eraseToAnyPublisher()
-                                }, dislike: { _ in
-                                    Just(true)
-                                        .setFailureType(to: Error.self)
-                                        .eraseToAnyPublisher()
-                                }
-                            )
+                            likeVideo: LikeVideoUseCaseMock()
                         )
                     )
                 )
             )
         }
+    }
+}
+
+struct LikeVideoUseCaseMock: LikeVideoUseCaseType {
+    func like(_ video: Video) -> AnyPublisher<Bool, Error> {
+        Just(true)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+    func dislike(_ video: Video) -> AnyPublisher<Bool, Error> {
+        Just(true)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
     }
 }
 

--- a/MyTube/Features/Video Detail/VideoDetailViewModel+Redux.swift
+++ b/MyTube/Features/Video Detail/VideoDetailViewModel+Redux.swift
@@ -37,7 +37,7 @@ extension VideoDetailViewModel {
     }
 
     struct Environment {
-        var likeVideo: LikeVideoUseCase
+        var likeVideo: LikeVideoUseCaseType
     }
 }
 
@@ -70,7 +70,7 @@ extension VideoDetailViewModel {
 
 extension VideoDetailViewModel {
     struct Effects {
-        static func like(video: Video, using useCase: LikeVideoUseCase) -> Effect<Action, Never> {
+        static func like(video: Video, using useCase: LikeVideoUseCaseType) -> Effect<Action, Never> {
             useCase.like(video)
                 .map { _ in Action.videoLiked }
                 .replaceError(with: .onLikeVideoError(.couldNotLikeVideo))
@@ -78,7 +78,7 @@ extension VideoDetailViewModel {
                 .eraseToEffect()
         }
 
-        static func dislike(video: Video, using useCase: LikeVideoUseCase) -> Effect<Action, Never> {
+        static func dislike(video: Video, using useCase: LikeVideoUseCaseType) -> Effect<Action, Never> {
             useCase.dislike(video)
                 .map { _ in Action.videoDisliked }
                 .replaceError(with: .onLikeVideoError(.couldNotDislikeVideo))
@@ -91,9 +91,9 @@ extension VideoDetailViewModel {
 extension VideoDetailViewModel.Environment {
     static var live: Self {
         .init(
-            likeVideo: .live(
-                repository: .coreData(
-                    repository: .live(
+            likeVideo: LikeVideoUseCase(
+                repository: CoreDataLikeVideoRepository(
+                    repository: CoreDataVideoPersistenceRepository(
                         managedObjectContext: PersistenceController.shared.container.viewContext)
                 )
             )

--- a/MyTube/Features/Videos List/VideosListView.swift
+++ b/MyTube/Features/Videos List/VideosListView.swift
@@ -87,11 +87,7 @@ struct VideosListView_Previews: PreviewProvider {
         VideosListView(
             viewModel: VideosListViewModel(
                 initialState: .init(loading: .loaded, videos: items),
-                environment: VideosListViewModel.Environment(searchVideos: SearchVideosUseCase(videosMatching: { _ in
-                    Just(items)
-                        .setFailureType(to: Error.self)
-                        .eraseToAnyPublisher()
-                }))
+                environment: VideosListViewModel.Environment(searchVideos: SearchVideosUseCaseMock(items: items))
             )
         )
     }
@@ -103,4 +99,14 @@ struct VideosListView_Previews: PreviewProvider {
     ]
 
     static let error: Error = NSError(domain: "Preview", code: 1, userInfo: [NSLocalizedDescriptionKey: "This is preview error."])
+}
+
+struct SearchVideosUseCaseMock: SearchVideosUseCaseType {
+    var items: [Video]
+
+    func videos(matching searchString: String) -> AnyPublisher<[Video], Error> {
+        Just(items)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
 }

--- a/MyTube/Features/Videos List/VideosListViewModel+Redux.swift
+++ b/MyTube/Features/Videos List/VideosListViewModel+Redux.swift
@@ -47,14 +47,14 @@ extension VideosListViewModel {
     }
 
     struct Environment {
-        var searchVideos: SearchVideosUseCase
+        var searchVideos: SearchVideosUseCaseType
     }
 }
 
 extension VideosListViewModel.Environment {
     static var live: Self {
         .init(
-            searchVideos: .live
+            searchVideos: SearchVideosUseCase()
         )
     }
 }
@@ -88,8 +88,8 @@ extension VideosListViewModel {
 
 extension VideosListViewModel {
     struct Effects {
-        static func searchStringPublisher(searchText: String, using useCase: SearchVideosUseCase) -> Effect<Action, Never> {
-            useCase.videosMatching(searchText)
+        static func searchStringPublisher(searchText: String, using useCase: SearchVideosUseCaseType) -> Effect<Action, Never> {
+            useCase.videos(matching: searchText)
                 .map(Action.onLoadVideos)
                 .replaceError(with: .onLoadVideosError(.unknown))
                 .eraseToAnyPublisher()


### PR DESCRIPTION
This PR aims to compare two ways of injecting dependencies
- Original code uses structs-based dependencies and is inspired by [ComposableArchitectures' `Environment`](https://github.com/pointfreeco/swift-composable-architecture) (also called [Protocol Witnesses](https://nsscreencast.com/episodes/486-codable-witnesses-1))
- This branch refactors dependencies to use more "traditional" way:  representing them using protocols and providing different implementations

## My personal observation on this comparison is following:

### Pros of struct-based approach:
- struct-based approach is bit shorter in therms of lines code
- using protocols really requires to repeat some stuff - [boilerplate as Stephen Celis says](https://www.pointfree.co/blog/posts/21-how-to-control-the-world)
- protocol-based code creates longer unit test files because of need to define stub/spy implementations for dependencies
- protocol-based code requires to add internal state (storing private vars for dependencies) whereas on struct-based version it can be just passed as a static method param
- in struct-based code, naming is easier because you don't have to come up with different protocol + implementation names. Also using static class func as a concrete implementation seems more "sexy" to me than creating new class/struct name. It's less different types overall. But more extensions.

### Cons of struct-based approach:
- struct-based code requires much more curly `{` brackets `}`, `in` keywords, new lines and tabulators. It's harder to read and get familiar with. Especially if junior devs are coming to your code base.
- even though unit test files are generally longer in protocol-based code, the test cases itself are bit shorter and more readable. Which is super important aspect for them. This however needs to be proven if its really an issue on larger codebase
- struct-based code initiates all structs keeping vars carrying closures at app start. So all this "logic" is loaded into memory even though it's not needed? Protocol-based code reaches to and executes given logic at a time it is needed (the method is called). Not sure if it's any performance/memory issue. All those closures might also increase the risk of entering retain cycles.

It's still a very little codebase on which are comparing these two principles and it's not a production app anyway.

Only time will tell which of these approaches is better. So far it seems to me it doesn't matter much which one you choose.